### PR TITLE
PS1-3: change span -> font to view colors on colab

### DIFF
--- a/psets/ps1-bio/pset1_bio_template.ipynb
+++ b/psets/ps1-bio/pset1_bio_template.ipynb
@@ -79,7 +79,7 @@
    "source": [
     "# Instructions\n",
     "\n",
-    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are shown in <span style=\"color:blue\">blue</span>, while grad-only points are shown in <span style=\"color:orange\">orange</span>. Total points: 75 (undergraduates) / 100 (graduates).\n",
+    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are shown in <font color=\"blue\">blue</font>, while grad-only points are shown in <font color=\"orange\">orange</font>. Total points: 75 (undergraduates) / 100 (graduates).\n",
     "\n",
     "- To get started, make your own copy of this notebook template in Colab (e.g., “Save a copy in Drive”) before editing.\n",
     "\n",
@@ -296,7 +296,7 @@
     "id": "328e1ed8-f30a-485f-9742-a8cb7e741174"
    },
    "source": [
-    "## 1.1 <span style=\"color:blue\">(5 points)</span> Load and inspect the raw data"
+    "## 1.1 <font color=\"blue\">(5 points)</font> Load and inspect the raw data"
    ]
   },
   {
@@ -395,7 +395,7 @@
     "tags": []
    },
    "source": [
-    "## 1.2 <span style=\"color:blue\">(5 points)</span> Generate train/test splits.\n",
+    "## 1.2 <font color=\"blue\">(5 points)</font> Generate train/test splits.\n",
     "\n",
     "To fairly evaluate the performance, split your data into a training data set and testing data set. Only training data should be used to train the model; testing data are for unbiased evaluations of model performance. During training, the model should not have access to *any* information about the testing dataset, so you should not train (or preprocess!) on the testing data.\n",
     "\n",
@@ -471,7 +471,7 @@
     "tags": []
    },
    "source": [
-    "## 1.3 <span style=\"color:blue\">(5 points)</span> Preprocess the data through scaling\n",
+    "## 1.3 <font color=\"blue\">(5 points)</font> Preprocess the data through scaling\n",
     "Features in your dataset may have different units and magnitudes (e.g., molecular weight vs. covalent radius). To avoid unfairly weighting features, we **standardize** all features to a consistent scale.\n",
     "\n",
     "Let $N$ be the total number of features and $M$ be the total sample size. Let the feature vector for the $j$-th sample be $\\{X_{0,j}, \\ldots, X_{i,j}, \\ldots, X_{N-1,j}\\}$, where $X_{i,j}$ is the unnormalized abundance of the $i$-th metabolite in the $j$-th patient. The mean and variance of each feature are:\n",
@@ -599,7 +599,7 @@
     "tags": []
    },
    "source": [
-    "## 1.4 <span style=\"color:blue\">(10 points)</span> Training a logistic regression classifier with `scikit-learn`\n",
+    "## 1.4 <font color=\"blue\">(10 points)</font> Training a logistic regression classifier with `scikit-learn`\n",
     "\n",
     "Now, you should be ready to train a logistic regression model and evaluate its performance on the test data. We will use simple model modules from `scikit-learn`, a machine learning library. We will use three handy evaluations for this task:\n",
     "\n",
@@ -767,7 +767,7 @@
     "tags": []
    },
    "source": [
-    "## 1.5 <span style=\"color:blue\">(5 points)</span> Introduce L1 regularization\n",
+    "## 1.5 <font color=\"blue\">(5 points)</font> Introduce L1 regularization\n",
     "In the previous part, you visualized the distribution of model coefficients. Now, we consider how these change after regularizing the model with L1 loss (we'll explore L2 regularization in Part 2). \n",
     "\n",
     "\n",
@@ -941,7 +941,7 @@
     "tags": []
    },
    "source": [
-    "## 1.6  <span style=\"color:blue\">(optional +2.5 points)</span> Connect model coefficients back to metabolites"
+    "## 1.6  <font color=\"blue\">(optional +2.5 points)</font> Connect model coefficients back to metabolites"
    ]
   },
   {
@@ -995,7 +995,7 @@
     "tags": []
    },
    "source": [
-    "## 1.7 <span style=\"color:blue\">(5 points)</span> Hyperparameter tuning the regularization parameter\n",
+    "## 1.7 <font color=\"blue\">(5 points)</font> Hyperparameter tuning the regularization parameter\n",
     "To optimize your model further, one may tune the hyperparameters, which are parameters whose values are used to control some aspect of the model or the learning process, but is not optimized during the training. These might include the layer widths, the number of layers, the learning rate, optimizer, and more. This is done for a number of reasons: to prevent overfitting, make training most efficient, improve generalization, etc.\n",
     "\n",
     "\n",
@@ -1053,7 +1053,7 @@
     "id": "69e3f5c0-db4d-4f96-8f7f-27a61675049f"
    },
    "source": [
-    "## 1.8 <span style=\"color:blue\">(5 points)</span> Training a random forest classifier with `scikit-learn`"
+    "## 1.8 <font color=\"blue\">(5 points)</font> Training a random forest classifier with `scikit-learn`"
    ]
   },
   {
@@ -1204,7 +1204,7 @@
     "tags": []
    },
    "source": [
-    "## 2.1: <span style=\"color:blue\">(5 points)</span> Encoding amino acids into feature vectors\n",
+    "## 2.1: <font color=\"blue\">(5 points)</font> Encoding amino acids into feature vectors\n",
     "\n",
     "\n",
     "After loading the pandas DataFrame, take a moment to inspect your data by looking at the rows (samples) and columns (features). The sequence of the peptide is stored in the column `Peptide`, and the binding affinity is stored in the column `Binding Affinity`.\n",
@@ -1543,7 +1543,7 @@
     "id": "d48b4ccf-2fba-42d0-901e-514484fcf680"
    },
    "source": [
-    "## 2.2 <span style=\"color:blue\">(10 points)</span> Define the MLP in PyTorch\n",
+    "## 2.2 <font color=\"blue\">(10 points)</font> Define the MLP in PyTorch\n",
     "\n",
     "We will now proceed to build a MLP using PyTorch’s `nn.Module` class. The `nn.Module` class requires two methods: an `__init__` method to define components and layers, and a `forward` method where you define the network's computation (i.e., how to compute a prediction with the layers given input data). Many standard layers, such as `nn.Linear` affine layers and activation layers like `nn.ReLU` or `nn.Tanh`, are provided by PyTorch. You can use an `nn.Sequential` module to stack layers so inputs are processed in order. We must make sure all layers are set as class attributes so PyTorch can handle automatic differentiation properly. "
    ]
@@ -1704,7 +1704,7 @@
     "tags": []
    },
    "source": [
-    "## 2.3 <span style=\"color:blue\">(10 points)</span> Implement functions for training and testing\n",
+    "## 2.3 <font color=\"blue\">(10 points)</font> Implement functions for training and testing\n",
     "\n",
     "Now with a defined model architecture and `DataLoader`s, we will set up the training. We initialize a model instance, `model`, and then an `optimizer` to perform backpropagation with a variant of stochastic gradient descent. Two options are stochastic gradient descent (`torch.optim.SGD`) or the Adam optimizer (`torch.optim.Adam`).\n",
     "\n",
@@ -1878,7 +1878,7 @@
     "tags": []
    },
    "source": [
-    "## 2.4 <span style=\"color:blue\">(5 points)</span> Train the multi-layer perceptron\n",
+    "## 2.4 <font color=\"blue\">(5 points)</font> Train the multi-layer perceptron\n",
     "\n",
     "For regression tasks, one metric we can use to evaluate model performance is the coefficient of determination, or the $R^2$ score. It is defined as:\n",
     "\n",
@@ -2067,7 +2067,7 @@
     "tags": []
    },
    "source": [
-    "## 2.5 <span style=\"color:orange\">(5 points) (grad)</span> Calculate model size\n",
+    "## 2.5 <font color=\"orange\">(5 points) (grad)</font> Calculate model size\n",
     "\n",
     "**Task 1**:\n",
     "Calculate the number of parameters used in your MLP given the provided `hidden_layer_sizes`. You can do this manually or iterate over `model.parameters()`. Calculate the total of number of parameters in your MLP model."
@@ -2156,7 +2156,7 @@
     "tags": []
    },
    "source": [
-    "## 2.6 <span style=\"color:blue\">(5 points)</span> Chemical transferability of one-hot representations\n",
+    "## 2.6 <font color=\"blue\">(5 points)</font> Chemical transferability of one-hot representations\n",
     "\n",
     "We created a holdout/test set, which includes amino acids in new positions not seen in the training set, to test your model's performance.\n",
     "\n",
@@ -2236,7 +2236,7 @@
     "tags": []
    },
    "source": [
-    "## 2.7 <span style=\"color:orange\">(10 points) (grad)</span> Featurize amino acids with physical descriptors\n",
+    "## 2.7 <font color=\"orange\">(10 points) (grad)</font> Featurize amino acids with physical descriptors\n",
     "\n",
     "Let's try using a more informative featurization, with physical descriptors of the amino acids. These physical descriptors were generated by the `peptide` package in Python and should provide physiochemical descriptions of various properties of amino acids.\n",
     "\n",
@@ -2319,7 +2319,7 @@
     "tags": []
    },
    "source": [
-    "## 2.8 <span style=\"color:orange\">(10 points) (grad)</span> Chemical transferability of physical descriptors\n",
+    "## 2.8 <font color=\"orange\">(10 points) (grad)</font> Chemical transferability of physical descriptors\n",
     "\n",
     "**Task 1**: Report the $R^2$ score on your holdout/test set using the model trained in the previous part and visualize your prediction with a scatter plot like you did before. "
    ]

--- a/psets/ps1-nonbio/pset1_nonbio_template.ipynb
+++ b/psets/ps1-nonbio/pset1_nonbio_template.ipynb
@@ -63,7 +63,7 @@
    "source": [
     "## Instructions\n",
     "\n",
-    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are in <span style=\"color:blue\">blue</span>, while grad-only points are in <span style=\"color:orange\">orange</span>. There is one problem that is undergrad only in <span style=\"color:purple\">purple</span>. The total points are 75 for undergraduates and 100 for graduates.\n",
+    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are in <font color=\"blue\">blue</font>, while grad-only points are in <font color=\"orange\">orange</font>. There is one problem that is undergrad only in <font style=\"color:purple\">purple</font>. The total points are 75 for undergraduates and 100 for graduates.\n",
     "  \n",
     "- To get started, make your own copy of this notebook template in Colab (e.g., “Save a copy in Drive”) before editing.\n",
     "\n",
@@ -303,7 +303,7 @@
     "id": "328e1ed8-f30a-485f-9742-a8cb7e741174"
    },
    "source": [
-    "## 1.1 <span style=\"color:blue\">(5 points) </span>  Load and inspect the raw data"
+    "## 1.1 <font color=\"blue\">(5 points) </font>  Load and inspect the raw data"
    ]
   },
   {
@@ -376,7 +376,7 @@
     "id": "_p_hkVa2rD65"
    },
    "source": [
-    "## 1.2 <span style=\"color:blue\">(5 points) </span>  Generate train/test splits."
+    "## 1.2 <font color=\"blue\">(5 points) </font>  Generate train/test splits."
    ]
   },
   {
@@ -444,7 +444,7 @@
     "id": "bcRExtbxq6Eb"
    },
    "source": [
-    "## 1.3 <span style=\"color:blue\">(5 points) </span> Preprocess the data through scaling"
+    "## 1.3 <font color=\"blue\">(5 points) </font> Preprocess the data through scaling"
    ]
   },
   {
@@ -558,7 +558,7 @@
     "id": "Wtr5s-pdr2c-"
    },
    "source": [
-    "## 1.4 <span style=\"color:blue\">(10 points) </span> Training a logistic regression classifier with `scikit-learn`"
+    "## 1.4 <font color=\"blue\">(10 points) </font> Training a logistic regression classifier with `scikit-learn`"
    ]
   },
   {
@@ -686,7 +686,7 @@
     "id": "G58jD4swuYsy"
    },
    "source": [
-    "## 1.5 <span style=\"color:blue\">(5 points) </span> Introduce L1 regularization"
+    "## 1.5 <font color=\"blue\">(5 points) </font> Introduce L1 regularization"
    ]
   },
   {
@@ -831,7 +831,7 @@
     "id": "a37d74ee-2908-4bef-87d8-eaed7b46d3f9"
    },
    "source": [
-    "## 1.6  <span style=\"color:blue\">(optional +2.5 points) </span>  Connect model coefficients back to metabolites"
+    "## 1.6  <font color=\"blue\">(optional +2.5 points) </font>  Connect model coefficients back to metabolites"
    ]
   },
   {
@@ -912,7 +912,7 @@
     "id": "10d73784-5c26-4d53-91a5-5a023c0d03c9"
    },
    "source": [
-    "## 1.7 <span style=\"color:blue\">(5 points) </span>  Hyperparameter tuning the regularization parameter"
+    "## 1.7 <font color=\"blue\">(5 points) </font>  Hyperparameter tuning the regularization parameter"
    ]
   },
   {
@@ -982,7 +982,7 @@
     "id": "69e3f5c0-db4d-4f96-8f7f-27a61675049f"
    },
    "source": [
-    "## 1.8 <span style=\"color:blue\">(5 points) </span>  Training a random forest classifier with `scikit-learn`"
+    "## 1.8 <font color=\"blue\">(5 points) </font>  Training a random forest classifier with `scikit-learn`"
    ]
   },
   {
@@ -1142,7 +1142,7 @@
    "id": "f9110cb0-41d6-4598-969a-ea019025e3be",
    "metadata": {},
    "source": [
-    "## 2.1: <span style=\"color:blue\">(5 points) </span> Encoding the data"
+    "## 2.1: <font color=\"blue\">(5 points) </font> Encoding the data"
    ]
   },
   {
@@ -1459,7 +1459,7 @@
     "id": "d48b4ccf-2fba-42d0-901e-514484fcf680"
    },
    "source": [
-    "## 2.2 <span style=\"color:blue\">(10 points) </span>   Define the MLP in PyTorch"
+    "## 2.2 <font color=\"blue\">(10 points) </font>   Define the MLP in PyTorch"
    ]
   },
   {
@@ -1627,7 +1627,7 @@
     "id": "cdf438c5-183d-46aa-9507-4169de131f20"
    },
    "source": [
-    "## 2.3 <span style=\"color:blue\">(10 points) </span>  Implement functions for training and testing"
+    "## 2.3 <font color=\"blue\">(10 points) </font>  Implement functions for training and testing"
    ]
   },
   {
@@ -1785,7 +1785,7 @@
     "id": "7cbd04ae-80bf-4502-bb8b-4fba5243f4cc"
    },
    "source": [
-    "## 2.4 <span style=\"color:blue\">(5 points) </span>  Train and validate your model."
+    "## 2.4 <font color=\"blue\">(5 points) </font>  Train and validate your model."
    ]
   },
   {
@@ -1922,7 +1922,7 @@
     "id": "2150e149-495e-4481-918f-e40d42ebd950"
    },
    "source": [
-    "## 2.5 <span style=\"color:orange\">(5 points) (grad) </span> Calculate model size\n",
+    "## 2.5 <font color=\"orange\">(5 points) (grad) </font> Calculate model size\n",
     "\n",
     "**Task**: Calculate the number of parameters used in your MLP given the provided `hidden_layer_sizes`. You can do this manually or iterate over `model.parameters()`. What does the input `hidden_layers_sizes = (256, 256, 256)` mean?"
    ]
@@ -1961,7 +1961,7 @@
     "id": "d8ac3c9d-c448-4225-8d99-b52aa7db2cf8"
    },
    "source": [
-    "## 2.6 <span style=\"color:blue\">(5 points) </span>Chemical Transferability of One-Hot Representations"
+    "## 2.6 <font color=\"blue\">(5 points) </font>Chemical Transferability of One-Hot Representations"
    ]
   },
   {
@@ -2030,7 +2030,7 @@
     "id": "f8c0d983-bf74-4bb3-b91e-d060177fad2b"
    },
    "source": [
-    "## 2.7 <span style=\"color:orange\">(10 points) (grad) </span> Featurize perovskites with physical descriptors"
+    "## 2.7 <font color=\"orange\">(10 points) (grad) </font> Featurize perovskites with physical descriptors"
    ]
   },
   {
@@ -2107,7 +2107,7 @@
     "id": "0e9d5a02-5361-4932-b358-12987ac0d827"
    },
    "source": [
-    "## 2.8 <span style=\"color:orange\">(10 points) (grad) </span> Chemical transferability of Physical Descriptors"
+    "## 2.8 <font color=\"orange\">(10 points) (grad) </font> Chemical transferability of Physical Descriptors"
    ]
   },
   {

--- a/psets/ps2-bio/pset2_bio_template.ipynb
+++ b/psets/ps2-bio/pset2_bio_template.ipynb
@@ -72,7 +72,7 @@
    "source": [
     "# Instructions\n",
     "\n",
-    "- This problem set has two modeling tasks with several sub-questions. Points for each section are shown in <span style=\"color:blue\">blue</span>. Total points: 100.\n",
+    "- This problem set has two modeling tasks with several sub-questions. Points for each section are shown in <font color=\"blue\">blue</font>. Total points: 100.\n",
     "\n",
     "- To get started, make your own copy of this notebook template in Colab (e.g., “Save a copy in Drive”) before editing.\n",
     "\n",
@@ -249,7 +249,7 @@
     "id": "PGGr1meefv-F"
    },
    "source": [
-    "### 1.1 <span style=\"color:blue\">(20 points) </span> Build Datasets and DataLoaders in PyTorch"
+    "### 1.1 <font color=\"blue\">(20 points) </font> Build Datasets and DataLoaders in PyTorch"
    ]
   },
   {
@@ -395,7 +395,7 @@
     "id": "yy0Uy4nffv-M"
    },
    "source": [
-    "### 1.2 <span style=\"color:blue\">(20 points) </span> Build an LSTM-based binding classifier"
+    "### 1.2 <font color=\"blue\">(20 points) </font> Build an LSTM-based binding classifier"
    ]
   },
   {
@@ -546,7 +546,7 @@
     "id": "PXqpwHtMfv-P"
    },
    "source": [
-    "### 1.3 <span style=\"color:blue\">(20 points) </span> Implement functions for training and testing"
+    "### 1.3 <font color=\"blue\">(20 points) </font> Implement functions for training and testing"
    ]
   },
   {
@@ -814,7 +814,7 @@
     "id": "QH39NmYzP6d5"
    },
    "source": [
-    "### 2.1 <span style=\"color:blue\">(20 points) </span> Build Datasets and DataLoaders"
+    "### 2.1 <font color=\"blue\">(20 points) </font> Build Datasets and DataLoaders"
    ]
   },
   {
@@ -980,7 +980,7 @@
     "id": "sTFqKeNGI2Af"
    },
    "source": [
-    "### 2.2 <span style=\"color:blue\">(20 points) </span> Train a U-Net Model that Performs Image Segmentation"
+    "### 2.2 <font color=\"blue\">(20 points) </font> Train a U-Net Model that Performs Image Segmentation"
    ]
   },
   {

--- a/psets/ps2-nonbio/pset2_nonbio_template.ipynb
+++ b/psets/ps2-nonbio/pset2_nonbio_template.ipynb
@@ -43,7 +43,7 @@
    "source": [
     "# Instructions\n",
     "\n",
-    "- This problem set has two modeling tasks with several sub-questions. Points for each section are shown in <span style=\"color:blue\">blue</span>. Total points: 100.\n",
+    "- This problem set has two modeling tasks with several sub-questions. Points for each section are shown in <font color=\"blue\">blue</font>. Total points: 100.\n",
     "\n",
     "- To get started, make your own copy of this notebook template in Colab (e.g., “Save a copy in Drive”) before editing.\n",
     "\n",
@@ -230,7 +230,7 @@
     "id": "1BFBZE25m2Bh"
    },
    "source": [
-    "### 1.1 <span style=\"color:blue\">(20 points) </span> Build Datasets and DataLoaders in PyTorch"
+    "### 1.1 <font color=\"blue\">(20 points) </font> Build Datasets and DataLoaders in PyTorch"
    ]
   },
   {
@@ -388,7 +388,7 @@
     "id": "uUbd6tbqnQkP"
    },
    "source": [
-    "### 1.2 <span style=\"color:blue\">(20 points) </span> Build an LSTM-based binding classifier\n"
+    "### 1.2 <font color=\"blue\">(20 points) </font> Build an LSTM-based binding classifier\n"
    ]
   },
   {
@@ -516,7 +516,7 @@
     "id": "vG33KAPJnuk5"
    },
    "source": [
-    "### 1.3 <span style=\"color:blue\">(20 points) </span> Implement functions for training and testing"
+    "### 1.3 <font color=\"blue\">(20 points) </font> Implement functions for training and testing"
    ]
   },
   {
@@ -729,7 +729,7 @@
     "tags": []
    },
    "source": [
-    "### 2.1 <span style=\"color:blue\">(20 points) </span> Build Datasets and DataLoaders"
+    "### 2.1 <font color=\"blue\">(20 points) </font> Build Datasets and DataLoaders"
    ]
   },
   {
@@ -869,7 +869,7 @@
     "id": "CLnX9Ev4379e"
    },
    "source": [
-    "### 2.2 <span style=\"color:blue\">(20 points) </span> Train a U-Net Model that Performs Image Segmentation"
+    "### 2.2 <font color=\"blue\">(20 points) </font> Train a U-Net Model that Performs Image Segmentation"
    ]
   },
   {

--- a/psets/ps3-SLGNN/pset3_bio_SLGNN_template.ipynb
+++ b/psets/ps3-SLGNN/pset3_bio_SLGNN_template.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "source": [
     "## Instructions\n",
-    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are in <span style=\"color:blue\">blue</span>, while grad-only points are in <span style=\"color:orange\">orange</span>. There is one problem that is undergrad only in <span style=\"color:purple\">purple</span>. The total points are 75 for undergraduates and 100 for graduates.\n",
+    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are in <font color=\"blue\">blue</font>, while grad-only points are in <font color=\"orange\">orange</font>. There is one problem that is undergrad only in <font color=\"purple\">purple</font>. The total points are 75 for undergraduates and 100 for graduates.\n",
     "- To get started, make your own copy of this notebook template in Colab (e.g., “Save a copy in Drive”) before editing.\n",
     "    - Important: this problem set requires a GPU. In Google Colab go to `Edit -> Notebook settings` and set the `Hardware accelerator` to a GPU before running the notebook (changing the runtime resets the notebook). See the GPU section below for additional help.\n",
     "- Collaboration is encouraged and AI tools are permitted, but submitting work that is not your own is plagiarism. Any collaboration or assistance from others or from an LLM (including utilities integrated in Colab) must be described at the end of your submission.\n",
@@ -285,7 +285,7 @@
     "tags": []
    },
    "source": [
-    "## 1.1 <span style=\"color:blue\">(5 points) </span> Get Data to construct a Knowledge Graph (KG)\n",
+    "## 1.1 <font color=\"blue\">(5 points) </font> Get Data to construct a Knowledge Graph (KG)\n",
     "\n",
     "**Run the code cells below and answer the questions that follow.**"
    ]
@@ -394,7 +394,7 @@
     "id": "bOU8cr6uOPoM"
    },
    "source": [
-    "## 1.2 <span style=\"color:blue\">(5 points) </span> Get Data to construct a SL graph & select gene pairs for training and validation\n",
+    "## 1.2 <font color=\"blue\">(5 points) </font> Get Data to construct a SL graph & select gene pairs for training and validation\n",
     "\n",
     "\n",
     "Run the code cells below and answer the following question. You will need to write some lines of code to answer Q1.\n"
@@ -547,7 +547,7 @@
     "id": "z7rjQGOuWWbx"
    },
    "source": [
-    "## 1.3 <span style=\"color:blue\">(25 points) </span> Construct SL graph"
+    "## 1.3 <font color=\"blue\">(25 points) </font> Construct SL graph"
    ]
   },
   {
@@ -675,7 +675,7 @@
     "id": "Zx-DoO5JUNlV"
    },
    "source": [
-    "## 1.4 <span style=\"color:blue\">(25 points) </span> Load KG Data to Construct Knowledge Graph"
+    "## 1.4 <font color=\"blue\">(25 points) </font> Load KG Data to Construct Knowledge Graph"
    ]
   },
   {
@@ -863,7 +863,7 @@
     "id": "1j27iVHgfUT1"
    },
    "source": [
-    "## 2.1 <span style=\"color:blue\">(5 points) </span> Create Datasets and Dataloaders for Training & Validation"
+    "## 2.1 <font color=\"blue\">(5 points) </font> Create Datasets and Dataloaders for Training & Validation"
    ]
   },
   {
@@ -972,7 +972,7 @@
     "id": "krvWmDzSUShu"
    },
    "source": [
-    "## 2.2 <span style=\"color:blue\">(7.5 points) </span> : Model Architecture"
+    "## 2.2 <font color=\"blue\">(7.5 points) </font> : Model Architecture"
    ]
   },
   {
@@ -1477,7 +1477,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## 2.3 <span style=\"color:blue\">(2.5 points) </span> Instantiate SL Model\n",
+    "## 2.3 <font color=\"blue\">(2.5 points) </font> Instantiate SL Model\n",
     "\n",
     "Here you will instantiate the model, move the model to the relevant device (cuda) as well as define the appropriate loss function (remember this is a classification task) and optimizer parameters. As in previous PSETs, you will be using the Adam optimizer to train the model. Once again, note the relevant hyperparameters have been defined in the **class ArgsConfig**."
    ]
@@ -1511,7 +1511,7 @@
     "id": "ROZqw0XdcC_d"
    },
    "source": [
-    "## 2.4 <span style=\"color:blue\">(10 points) </span> Train & Evaluate Model (~8min if using A100)\n",
+    "## 2.4 <font color=\"blue\">(10 points) </font> Train & Evaluate Model (~8min if using A100)\n",
     "\n",
     "Adapt the code shown in the Colab notebook to loop over the training and validation sets. Make sure to save the training and validation losses in the relevant lists and compute the relevant metrics during validation. Note that the loss being minimized during model training is a summed loss, including the Binary Cross-Entropy (BCE) loss (`torch.nn.BCELoss()`), a regularization (L2) loss, and a correlation loss based on a distance metric (the latter encourages the model to learn relationships between nodes that accurately reflect the graph structure). \\\\\n",
     "\n",
@@ -1600,7 +1600,7 @@
     "id": "AvRkPY6By_RP"
    },
    "source": [
-    "### 2.5 <span style=\"color:blue\">(5 points) </span> Plot Results (~1 min)\n",
+    "### 2.5 <font color=\"blue\">(5 points) </font> Plot Results (~1 min)\n",
     "\n",
     "**There are three total tasks.**\n",
     "\n",
@@ -1681,7 +1681,7 @@
     "id": "_WdH6l6CwUgE"
    },
    "source": [
-    "# 3. <span style=\"color:blue\">(10 points) </span> Investigating one SL gene pair of interest\n",
+    "# 3. <font color=\"blue\">(10 points) </font> Investigating one SL gene pair of interest\n",
     "\n",
     "**This question requires no coding, just answer it in a markdown cell below.**"
    ]

--- a/psets/ps3-nonbio/pset3_nonbio_template.ipynb
+++ b/psets/ps3-nonbio/pset3_nonbio_template.ipynb
@@ -68,7 +68,7 @@
    "source": [
     "# Instructions\n",
     "\n",
-    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are in <span style=\"color:blue\">blue</span>, while grad-only points are in <span style=\"color:orange\">orange</span>. There is one problem that is undergrad only in <span style=\"color:purple\">purple</span>. The total points are 75 for undergraduates and 100 for graduates.\n",
+    "- This problem set has two modeling tasks with several sub-questions. Some are marked grad version, which are required for graduate students (X.C51) but optional for others. Points for all students are in <font color=\"blue\">blue</font>, while grad-only points are in <font color=\"orange\">orange</font>. There is one problem that is undergrad only in <font color=\"purple\">purple</font>. The total points are 75 for undergraduates and 100 for graduates.\n",
     "  \n",
     "- To get started, make your own copy of this notebook template in Colab (e.g., “Save a copy in Drive”) before editing.\n",
     "\n",
@@ -244,7 +244,7 @@
     "id": "Vh92cyI0RyKr"
    },
    "source": [
-    "## 1.1 <span style=\"color:blue\">(5 points) </span> Load and visualize some molecules with `RDKit`\n",
+    "## 1.1 <font color=\"blue\">(5 points) </font> Load and visualize some molecules with `RDKit`\n",
     "\n",
     "RDKit is a open-source cheminformatics package that can process and manipulate molecular structures to work with molecules in their natural graph format. Follow the example code to create a `rdkit.Chem.rdchem.Mol` object and visualize it as a 2D line drawing. "
    ]
@@ -311,7 +311,7 @@
     "id": "vwfUlfMiSzjE"
    },
    "source": [
-    "## <a name=\"dataprocessing\"></a> 1.2 <span style=\"color:blue\">(5 points) </span> Collect atom and bond information for a sample molecule"
+    "## <a name=\"dataprocessing\"></a> 1.2 <font color=\"blue\">(5 points) </font> Collect atom and bond information for a sample molecule"
    ]
   },
   {
@@ -464,7 +464,7 @@
     "id": "ecD7XuW5wZFz"
    },
    "source": [
-    "## Part 1.3: <span style=\"color:blue\">(5 points) </span> Process all samples in the dataset with `smiles2features`"
+    "## Part 1.3: <font color=\"blue\">(5 points) </font> Process all samples in the dataset with `smiles2features`"
    ]
   },
   {
@@ -540,7 +540,7 @@
     "id": "UjQrqtF04ylY"
    },
    "source": [
-    "## Part 1.4 <span style=\"color:blue\">(5 points) </span> Construct molecular graph `Datasets` and `DataLoaders`"
+    "## Part 1.4 <font color=\"blue\">(5 points) </font> Construct molecular graph `Datasets` and `DataLoaders`"
    ]
   },
   {
@@ -1028,7 +1028,7 @@
     "id": "QIB1VXx4VL6b"
    },
    "source": [
-    "## Part 1.5.grad <span style=\"color:orange\">(20 points, grad) </span> Complete the definition of a GNN\n",
+    "## Part 1.5.grad <font color=\"orange\">(20 points, grad) </font> Complete the definition of a GNN\n",
     "Undergrad students, complete `1.5.undergrad` (next cell)."
    ]
   },
@@ -1124,7 +1124,7 @@
     "id": "VQm-dS9QJo48"
    },
    "source": [
-    "## Part 1.5.undergrad <span style=\"color:purple\">(10 points, undergrad)  </span> Define the first embedding layers of a GNN\n",
+    "## Part 1.5.undergrad <font color=\"purple\">(10 points, undergrad)  </font> Define the first embedding layers of a GNN\n",
     "Graduate students, do not complete this cell, only complete 1.5.grad (previous cell)."
    ]
   },
@@ -1205,7 +1205,7 @@
     "id": "j7pwjIioXD5i"
    },
    "source": [
-    "## Part 1.6.grad <span style=\"color:orange\">(5 points grad) </span> Verify that your GNN preserves permutational invariance"
+    "## Part 1.6.grad <font color=\"orange\">(5 points grad) </font> Verify that your GNN preserves permutational invariance"
    ]
   },
   {
@@ -1302,7 +1302,7 @@
     "id": "XsluOOWpY9yh"
    },
    "source": [
-    "## Part 1.7 <span style=\"color:blue\">(5 points) </span> Train and test your GNN"
+    "## Part 1.7 <font color=\"blue\">(5 points) </font> Train and test your GNN"
    ]
   },
   {
@@ -1484,7 +1484,7 @@
     "id": "3SAoHLugFlIu"
    },
    "source": [
-    "## Part 1.8 <span style=\"color:blue\">(5 points) </span>  How do \"identical\" molecules compare?\n",
+    "## Part 1.8 <font color=\"blue\">(5 points) </font>  How do \"identical\" molecules compare?\n",
     "\n",
     "Now that your GNN model can predict molecular solubilities, let's apply it to a pair of closely related molecules. The second molecule is a deprotonated version of the first, but otherwise have identical molecular connectivity. These subtle differences in their protonation states can significantly affect the intermolecular interactions with solvents like water. Solubility is sensitive to such changes, as variations in protonation influence how these molecules interact with the surrounding solvent environment."
    ]
@@ -1583,7 +1583,7 @@
     "id": "e6o6RZnXFyID"
    },
    "source": [
-    "## Part 1.9 <span style=\"color:orange\">(10 points grad) </span>  Obtain and compare node-level embeddings of these molecules\n",
+    "## Part 1.9 <font color=\"orange\">(10 points grad) </font>  Obtain and compare node-level embeddings of these molecules\n",
     "\n",
     "Using the above molecules, let's dig a little deeper into the predictions from the model.\n",
     "\n",
@@ -1696,7 +1696,7 @@
     "id": "zbo2KkrM3SGk"
    },
    "source": [
-    "## Part 2.1: <span style=\"color:blue\">(10 points) </span>  Explore the data distribution in the dataset\n",
+    "## Part 2.1: <font color=\"blue\">(10 points) </font>  Explore the data distribution in the dataset\n",
     "\n",
     "As mentioned in the background, molecular conformation and thus stereochemistry can influence the binding affinity and thereby $IC_{50}$ considerably. An unfavorable conformation can break important protein-ligand interactions. To get an idea of this property, let's view what kinds of stereochemistry are present in the data.\n",
     "\n",
@@ -1766,7 +1766,7 @@
     "id": "Au3znAlMbvEx"
    },
    "source": [
-    "## Part 2.2: <span style=\"color:blue\">(5 points) </span> Process the data into feature lists\n",
+    "## Part 2.2: <font color=\"blue\">(5 points) </font> Process the data into feature lists\n",
     "**Task 1:** Load this dataset with pandas, and process the SMILES with your code from part 1.2 to encode them into 2D graphs. Use the `pIC50` column for the  values you will predict in this task.\n",
     "\n",
     "Your code should reuse much of the processing from Problem 1, with two main changes:\n",
@@ -1854,7 +1854,7 @@
     "id": "Qz71ujG9bvEx"
    },
    "source": [
-    "## 2.3 <span style=\"color:blue\">(10 points) </span>  Train and evaluate your GNN's performance overall and by chiral center count"
+    "## 2.3 <font color=\"blue\">(10 points) </font>  Train and evaluate your GNN's performance overall and by chiral center count"
    ]
   },
   {
@@ -2000,7 +2000,7 @@
     "id": "pArTx8jWbvEx"
    },
    "source": [
-    "## Part 2.4 <span style=\"color:blue\">(10 points) </span>  How do two stereoisomers compare?\n",
+    "## Part 2.4 <font color=\"blue\">(10 points) </font>  How do two stereoisomers compare?\n",
     "\n",
     "The dataset includes multiple sets of stereoisomers (molecules that have the same 2D connectivity but differ in their stereochemistry). You may have potentially stumbled upon these when exploring the data in 2.1.\n",
     "\n",


### PR DESCRIPTION
For some reason, <span> tags to color text in markdown cells doesn't render in Colab notebooks.

Switched from:
`<span style="color:COLOR">text</span>`
to
`<font color="COLOR">text</font>`

for PS 1-3